### PR TITLE
The variable name $body is ambiguous in Client::post

### DIFF
--- a/src/WebService/Client.php
+++ b/src/WebService/Client.php
@@ -100,8 +100,8 @@ class Client
      */
     public function post($service, $path, $input)
     {
-        $body = json_encode($input);
-        if ($body === false) {
+        $requestBody = json_encode($input);
+        if ($requestBody === false) {
             throw new InvalidInputException(
                 'Error encoding input as JSON: '
                 . $this->jsonErrorDescription()
@@ -113,12 +113,12 @@ class Client
             ['Content-Type: application/json']
         );
 
-        list($statusCode, $contentType, $body) = $request->post($body);
+        list($statusCode, $contentType, $responseBody) = $request->post($requestBody);
 
         return $this->handleResponse(
             $statusCode,
             $contentType,
-            $body,
+            $responseBody,
             $service,
             $path
         );
@@ -128,12 +128,12 @@ class Client
     {
         $request = $this->createRequest($path);
 
-        list($statusCode, $contentType, $body) = $request->get();
+        list($statusCode, $contentType, $responseBody) = $request->get();
 
         return $this->handleResponse(
             $statusCode,
             $contentType,
-            $body,
+            $responseBody,
             $service,
             $path
         );
@@ -170,11 +170,11 @@ class Client
     }
 
     /**
-     * @param int    $statusCode  the HTTP status code of the response
-     * @param string $contentType the Content-Type of the response
-     * @param string $body        the response body
-     * @param string $service     the name of the service
-     * @param string $path        the path used in the request
+     * @param int    $statusCode   the HTTP status code of the response
+     * @param string $contentType  the Content-Type of the response
+     * @param string $responseBody the response body
+     * @param string $service      the name of the service
+     * @param string $path         the path used in the request
      *
      * @throws AuthenticationException    when there is an issue authenticating the
      *                                    request
@@ -190,19 +190,19 @@ class Client
     private function handleResponse(
         $statusCode,
         $contentType,
-        $body,
+        $responseBody,
         $service,
         $path
     ) {
         if ($statusCode >= 400 && $statusCode <= 499) {
-            $this->handle4xx($statusCode, $contentType, $body, $service, $path);
+            $this->handle4xx($statusCode, $contentType, $responseBody, $service, $path);
         } elseif ($statusCode >= 500) {
             $this->handle5xx($statusCode, $service, $path);
         } elseif ($statusCode !== 200) {
             $this->handleUnexpectedStatus($statusCode, $service, $path);
         }
 
-        return $this->handleSuccess($body, $service);
+        return $this->handleSuccess($responseBody, $service);
     }
 
     /**


### PR DESCRIPTION
The current Client::handleSuccess docblock confuses the terms "request" and "response".